### PR TITLE
Support pre/post_activate venv hooks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -72,8 +72,8 @@ source $BIN_DIR/utils
 # Switch to the repo's context.
 cd $BUILD_DIR
 
-# Experimental pre_compile hook.
-source $BIN_DIR/steps/hooks/pre_compile
+# Run pre_compile hook.
+run-hook bin/pre_compile
 
 # If no requirements given, assume `setup.py develop`.
 if [ ! -f requirements.txt ]; then
@@ -131,8 +131,14 @@ set -e
 # See [`bin/steps/pylibmc`](pylibmc.html).
 source $BIN_DIR/steps/pylibmc
 
+# Run post_activate venv hook
+run-hook bin/pre_activate
+
 # Activate the Virtualenv.
 source $VIRTUALENV_LOC/bin/activate
+
+# Run post_activate venv hook
+run-hook bin/post_activate
 
 # Install Mercurial if it appears to be required.
 if (grep -Fiq "hg+" requirements.txt) then
@@ -183,7 +189,7 @@ set-default-env PYTHONPATH /app/
 
 # ### Fin.
 
-# Experimental post_compile hook.
-source $BIN_DIR/steps/hooks/post_compile
+# Run post_compile hook.
+run-hook bin/post_compile
 
 # <a href="http://github.com/heroku/heroku-buildpack-python"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://d3nwyuy0nl342s.cloudfront.net/img/7afbc8b248c68eb468279e8c17986ad46549fb71/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub"></a>

--- a/bin/steps/hooks/post_compile
+++ b/bin/steps/hooks/post_compile
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-if [ -f bin/post_compile ]; then
-    echo "-----> Running post-compile hook"
-    chmod +x bin/post_compile
-    bin/post_compile
-fi

--- a/bin/steps/hooks/pre_compile
+++ b/bin/steps/hooks/pre_compile
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-if [ -f bin/pre_compile ]; then
-    echo "-----> Running pre-compile hook"
-    chmod +x bin/pre_compile
-    bin/pre_compile
-fi

--- a/bin/utils
+++ b/bin/utils
@@ -34,3 +34,12 @@ function set-env (){
 function set-default-env (){
   echo "export $1=\${$1:-$2}" >> $PROFILE_PATH
 }
+
+# Run a hook script
+function run-hook () {
+    if [ -f $1 ]; then
+        echo "-----> Running $1 hook"
+        chmod +x $1
+        env PATH=$VIRTUALENV_LOC/bin:$PATH VIRTUALENV_LOC=$VIRTUALENV_LOC $1
+    fi
+}


### PR DESCRIPTION
Expose VIRTUALENV_LOC and PATH to run-hooks, so one can run things like
`pip install --upgrade pip` inside the venv.
